### PR TITLE
Updated hmac key to version 5.104.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 THIS IS JUST A FORK OF THE OFFICIAL PROJECT 
 =========
 
-- Some minor changes to make it work again (as of 5.77.0)
-- Updated HMAC-Key to 5.77.0
+- Some minor changes to make it work again (as of 5.104.1)
+- Updated HMAC-Key to 5.104.1
 - Partially fixed the gcmhack
 - Fixed the sign up and upvote requests (others are untested)
 - THE FIXES WERE DONE QUICK AND DIRTY, THIS CODE COULD BREAK AT ANY TIME

--- a/src/jodel_api/jodel_api.py
+++ b/src/jodel_api/jodel_api.py
@@ -26,8 +26,8 @@ class JodelAccount:
 
     api_url = "https://api.go-tellm.com/api{}"
     client_id = '81e8a76e-1e02-4d17-9ba0-8a7020261b26'
-    secret = 'SzsuLtrabXwYuAqZoAmvFypvZdZrYydEOCqoORiy'.encode('ascii')
-    version = '5.77.0'
+    secret = 'MMSPnASRTEWYXVvlbsrVfrPeiMlxsPDFBpqUyNMN'.encode('ascii')
+    version = '5.104.1'
 
     access_token = None
     device_uid = None


### PR DESCRIPTION
Updated the hmac key used for message signing to the current version (5.104.1)